### PR TITLE
Changed message heading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,13 +91,13 @@ export async function run() {
           issue_number: context.issue.number,
           owner: context.repo.owner,
           repo: context.repo.repo,
-          body: `### Validation failed!\n${body}`,
+          body: `### PnP sample manifest validation failed!\n${body}`,
         });
       } catch (error) {
         console.log(body);
       }
 
-      setFailed("Invalid samples!");
+      setFailed("Invalid sample!");
     }
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
When combined with other sample validation workflows, "Sample validation failed" is too generic of a message for the PnP repo maintainers.

This simple change makes the output message more specific.

Changes were already discussed with @VesaJuvonen and @PaoloPia 